### PR TITLE
fix meal plan creation and protect progress routes

### DIFF
--- a/backend/routes/nutrition.js
+++ b/backend/routes/nutrition.js
@@ -263,7 +263,7 @@ router.post('/meal-plans', auth, async (req, res) => {
           date,
           notes: notes || null,
           isPublic: Boolean(isPublic),
-          userId
+          user: { connect: { id: userId } }
         }
       });
       
@@ -515,7 +515,7 @@ router.post('/mealplans', auth, async (req, res) => {
       data: {
         name,
         description,
-        is_public: isPublic ?? false, // Correção: usar is_public
+        isPublic: isPublic ?? false,
         user: { connect: { id: userId } },
       },
     });

--- a/backend/routes/progress.js
+++ b/backend/routes/progress.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { PrismaClient } = require('@prisma/client');
+const auth = require('../middleware/auth');
 
 const prisma = new PrismaClient();
 
@@ -35,7 +36,7 @@ router.get('/workout', auth, async (req, res) => {
 });
 
 // Get food diary entries for user
-router.get('/nutrition', async (req, res) => {
+router.get('/nutrition', auth, async (req, res) => {
   try {
     const userId = req.user?.id;
     
@@ -65,7 +66,7 @@ router.get('/nutrition', async (req, res) => {
 });
 
 // Add device data
-router.post('/device', async (req, res) => {
+router.post('/device', auth, async (req, res) => {
   try {
     const userId = req.user?.id;
     


### PR DESCRIPTION
## Summary
- ensure progress endpoints validate auth tokens and only run for logged users
- fix meal plan creation to correctly associate with owner and persist visibility flag

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689164a6627883298e2231c01ddcf910