### PR TITLE
Rename StrengthSprint to ForgeNFuel

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -45,7 +45,7 @@ app.use((req, res, next) => {
 
 // Basic route
 app.get('/', (req, res) => {
-  res.send('StrengthSprint API is running');
+  res.send('ForgeNFuel API is running');
 });
 
 // Routes setup

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -31,7 +31,7 @@ const Logo: React.FC<LogoProps> = ({ size = 'medium' }) => {
     <div className={containerClass}>
       <Activity size={iconSize} className="text-fitness-primary" />
       <span className={`${textClass} text-fitness-primary`}>
-        Strength<span className="text-fitness-secondary">Sprint</span>
+        Forge<span className="text-fitness-secondary">NFuel</span>
       </span>
     </div>
   );

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -82,7 +82,7 @@ const Navbar = () => {
                 <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg opacity-0 group-hover:opacity-20 transition-opacity blur-xl"></div>
               </div>
               <span className="text-xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                StrengthSprint
+                ForgeNFuel
               </span>
             </Link>
             

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -30,8 +30,8 @@ const LandingPage = () => {
               Seu Companheiro para Fitness e Nutrição
             </h1>
             <p className="text-xl text-gray-700">
-              Monitore seus treinos, planeje suas refeições e alcance seus objetivos de forma eficiente 
-              com a plataforma completa StrengthSprint.
+              Monitore seus treinos, planeje suas refeições e alcance seus objetivos de forma eficiente
+              com a plataforma completa ForgeNFuel.
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
               <Button asChild size="lg" className="bg-fitness-primary hover:bg-fitness-primary/90">
@@ -45,7 +45,7 @@ const LandingPage = () => {
           <div className="lg:w-1/2">
             <img 
               src="/dashboard-preview.png" 
-              alt="Dashboard do StrengthSprint" 
+              alt="Dashboard do ForgeNFuel"
               className="rounded-lg shadow-2xl"
             />
           </div>
@@ -108,7 +108,7 @@ const LandingPage = () => {
             <TestimonialCard 
               name="Carlos Silva"
               role="Usuário há 6 meses"
-              quote="O StrengthSprint mudou completamente minha abordagem de treino. Consigo planejar e acompanhar tudo de forma muito mais eficiente."
+              quote="O ForgeNFuel mudou completamente minha abordagem de treino. Consigo planejar e acompanhar tudo de forma muito mais eficiente."
             />
             <TestimonialCard 
               name="Marina Santos"
@@ -129,7 +129,7 @@ const LandingPage = () => {
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-3xl font-bold mb-4">Pronto para Transformar seus Hábitos?</h2>
           <p className="text-xl text-gray-700 mb-8 max-w-3xl mx-auto">
-            Junte-se a milhares de pessoas que já estão alcançando seus objetivos com o StrengthSprint.
+            Junte-se a milhares de pessoas que já estão alcançando seus objetivos com o ForgeNFuel.
           </p>
           <Button asChild size="lg" className="bg-fitness-primary hover:bg-fitness-primary/90">
             <Link to="/auth/register">Começar Gratuitamente</Link>
@@ -153,7 +153,7 @@ const LandingPage = () => {
             </div>
           </div>
           <div className="text-center text-gray-400">
-            <p>&copy; {new Date().getFullYear()} StrengthSprint. Todos os direitos reservados.</p>
+            <p>&copy; {new Date().getFullYear()} ForgeNFuel. Todos os direitos reservados.</p>
           </div>
         </div>
       </footer>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -43,7 +43,7 @@ const Login = () => {
       if (result.success) {
         toast({
           title: "Login realizado com sucesso",
-          description: "Bem-vindo de volta ao StrengthSprint!",
+          description: "Bem-vindo de volta ao ForgeNFuel!",
         });
         navigate('/');
       } else {
@@ -72,7 +72,7 @@ const Login = () => {
           <div className="flex justify-center mb-4">
             <Logo size="large" />
           </div>
-          <CardTitle className="text-2xl font-bold">Entrar no StrengthSprint</CardTitle>
+          <CardTitle className="text-2xl font-bold">Entrar no ForgeNFuel</CardTitle>
           <CardDescription>
             Entre para acompanhar seus treinos e planos alimentares
           </CardDescription>
@@ -148,7 +148,7 @@ const Login = () => {
                 if (result.success) {
                   toast({
                     title: "Login realizado com sucesso",
-                    description: "Bem-vindo de volta ao StrengthSprint!",
+                    description: "Bem-vindo de volta ao ForgeNFuel!",
                   });
                   navigate('/');
                 } else {

--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -62,7 +62,7 @@ const Register = () => {
       if (result.success) {
         toast({
           title: "Registro realizado com sucesso",
-          description: "Bem-vindo ao StrengthSprint!",
+          description: "Bem-vindo ao ForgeNFuel!",
         });
         navigate('/');
       } else {
@@ -98,7 +98,7 @@ const Register = () => {
           </div>
           <CardTitle className="text-2xl font-bold">Crie sua conta</CardTitle>
           <CardDescription>
-            Comece sua jornada de fitness e nutrição com o StrengthSprint
+            Comece sua jornada de fitness e nutrição com o ForgeNFuel
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary
- rebrand application from StrengthSprint to ForgeNFuel across frontend and backend
- update logo, navigation, landing, auth pages, and API root message to use ForgeNFuel name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68a53a0bee448329aaf95ed32dd193ca