### PR TITLE
Refactor theme to purple and streamline navigation

### DIFF
--- a/src/components/dashboard/NotificationList.tsx
+++ b/src/components/dashboard/NotificationList.tsx
@@ -26,8 +26,8 @@ const NotificationList = () => {
 
   const getNotificationStyle = (type: string) => {
     const styleMap = {
-      'workout': 'from-blue-50 to-indigo-50 border-blue-200',
-      'nutrition': 'from-green-50 to-emerald-50 border-green-200',
+      'workout': 'from-purple-50 to-purple-50 border-purple-200',
+      'nutrition': 'from-purple-50 to-purple-50 border-purple-200',
       'achievement': 'from-yellow-50 to-orange-50 border-yellow-200',
       'reminder': 'from-purple-50 to-pink-50 border-purple-200',
       'info': 'from-gray-50 to-slate-50 border-gray-200'
@@ -55,11 +55,11 @@ const NotificationList = () => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="bg-gradient-to-br from-indigo-50 to-purple-50 border border-indigo-200 hover:shadow-xl transition-all duration-300">
+      <Card className="bg-gradient-to-br from-purple-50 to-purple-50 border border-purple-200 hover:shadow-xl transition-all duration-300">
         <CardHeader className="pb-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center">
+              <div className="w-10 h-10 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl flex items-center justify-center">
                 <Bell size={20} className="text-white" />
               </div>
               <div>
@@ -105,7 +105,7 @@ const NotificationList = () => {
                     <div className="flex items-start gap-3">
                       <div className={`
                         p-2 rounded-lg shrink-0
-                        ${notification.type === 'workout' ? 'bg-blue-100 text-blue-600' :
+                        ${notification.type === 'workout' ? 'bg-purple-100 text-purple-600' :
                           'bg-gray-100 text-gray-600'
                         }
                       `}>
@@ -130,7 +130,7 @@ const NotificationList = () => {
                                 e.stopPropagation();
                                 handleMarkAsRead(notification.id);
                               }}
-                              className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-600 hover:text-blue-700 bg-blue-100 hover:bg-blue-200 rounded-full transition-colors"
+                              className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-purple-600 hover:text-purple-700 bg-purple-100 hover:bg-purple-200 rounded-full transition-colors"
                             >
                               <Check size={12} />
                               Marcar
@@ -156,7 +156,7 @@ const NotificationList = () => {
                       </div>
                       
                       {!notification.read && (
-                        <div className="w-2 h-2 bg-blue-500 rounded-full shrink-0 mt-2" />
+                        <div className="w-2 h-2 bg-purple-500 rounded-full shrink-0 mt-2" />
                       )}
                     </div>
                   </motion.div>
@@ -170,7 +170,7 @@ const NotificationList = () => {
                   transition={{ delay: 0.5 }}
                   className="text-center pt-4"
                 >
-                  <Button asChild variant="outline" size="sm" className="hover:bg-indigo-50 hover:text-indigo-600 border-indigo-200">
+                  <Button asChild variant="outline" size="sm" className="hover:bg-purple-50 hover:text-purple-600 border-purple-200">
                     <a href="/notifications">Ver todas ({notifications.length})</a>
                   </Button>
                 </motion.div>

--- a/src/components/dashboard/NutritionGoalsFeedback.tsx
+++ b/src/components/dashboard/NutritionGoalsFeedback.tsx
@@ -102,9 +102,9 @@ const NutritionGoalsFeedback = () => {
                 key={index}
                 variant={msg.type === "success" ? "default" : msg.type === "warning" ? "destructive" : "outline"}
                 className={`
-                  ${msg.type === "success" ? "bg-green-50 text-green-800 border-green-200" : ""}
+                  ${msg.type === "success" ? "bg-purple-50 text-purple-800 border-purple-200" : ""}
                   ${msg.type === "warning" ? "bg-yellow-50 text-yellow-800 border-yellow-200" : ""}
-                  ${msg.type === "info" ? "bg-blue-50 text-blue-800 border-blue-200" : ""}
+                  ${msg.type === "info" ? "bg-purple-50 text-purple-800 border-purple-200" : ""}
                 `}
               >
                 <AlertDescription>{msg.message}</AlertDescription>
@@ -125,7 +125,7 @@ const NutritionGoalsFeedback = () => {
           <div className="mt-4 grid grid-cols-3 text-center gap-2">
             <div>
               <p className="text-xs text-gray-500">Proteínas</p>
-              <p className="text-lg font-bold text-blue-600">{percentages.protein}%</p>
+              <p className="text-lg font-bold text-purple-600">{percentages.protein}%</p>
             </div>
             <div>
               <p className="text-xs text-gray-500">Carboidratos</p>

--- a/src/components/dashboard/NutritionProgress.tsx
+++ b/src/components/dashboard/NutritionProgress.tsx
@@ -49,8 +49,8 @@ const NutritionProgress = () => {
       current: todayNutrition.calories,
       goal: goals.calories,
       unit: 'kcal',
-      color: 'from-blue-500 to-blue-600',
-      bgColor: 'from-blue-50 to-blue-100',
+      color: 'from-purple-500 to-purple-600',
+      bgColor: 'from-purple-50 to-purple-100',
       icon: '🔥'
     },
     {
@@ -58,8 +58,8 @@ const NutritionProgress = () => {
       current: todayNutrition.protein,
       goal: goals.protein,
       unit: 'g',
-      color: 'from-green-500 to-green-600',
-      bgColor: 'from-green-50 to-green-100',
+      color: 'from-purple-500 to-purple-600',
+      bgColor: 'from-purple-50 to-purple-100',
       icon: '💪'
     },
     {
@@ -134,7 +134,7 @@ const NutritionProgress = () => {
                         animate={{ scale: 1 }}
                         transition={{ delay: 0.5 + index * 0.1 }}
                       >
-                        <TrendingUp size={16} className="text-green-600" />
+                        <TrendingUp size={16} className="text-purple-600" />
                       </motion.div>
                     )}
                   </div>
@@ -145,7 +145,7 @@ const NutritionProgress = () => {
                         {Math.round(item.current)}/{item.goal} {item.unit}
                       </span>
                       <span className={`font-bold ${
-                        isOnTrack ? 'text-green-600' : percentage > 120 ? 'text-red-600' : 'text-yellow-600'
+                        isOnTrack ? 'text-purple-600' : percentage > 120 ? 'text-red-600' : 'text-yellow-600'
                       }`}>
                         {percentage}%
                       </span>
@@ -173,7 +173,7 @@ const NutritionProgress = () => {
                     </span>
                     <span className={`px-2 py-1 rounded-full font-medium ${
                       isOnTrack 
-                        ? 'bg-green-100 text-green-700'
+                        ? 'bg-purple-100 text-purple-700'
                         : percentage > 120 
                         ? 'bg-red-100 text-red-700'
                         : 'bg-yellow-100 text-yellow-700'

--- a/src/components/dashboard/TodayMeals.tsx
+++ b/src/components/dashboard/TodayMeals.tsx
@@ -30,7 +30,7 @@ const TodayMeals = () => {
             </div>
             <h3 className="text-lg font-semibold text-gray-700 mb-2">Sem Plano Alimentar</h3>
             <p className="text-gray-500 mb-4">Nenhuma refeição planejada para hoje</p>
-            <Button asChild variant="outline" className="hover:bg-green-50 hover:text-green-600 border-green-200">
+            <Button asChild variant="outline" className="hover:bg-purple-50 hover:text-purple-600 border-purple-200">
               <Link to="/nutrition/planning">Planejar refeições</Link>
             </Button>
           </CardContent>
@@ -64,10 +64,10 @@ const TodayMeals = () => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border border-green-200 hover:shadow-xl transition-all duration-300">
+      <Card className="bg-gradient-to-br from-purple-50 to-purple-50 border border-purple-200 hover:shadow-xl transition-all duration-300">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl flex items-center justify-center">
+            <div className="w-10 h-10 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl flex items-center justify-center">
               <Utensils size={20} className="text-white" />
             </div>
             <div>
@@ -86,7 +86,7 @@ const TodayMeals = () => {
               <p className="text-xs text-gray-600">kcal</p>
             </div>
             <div className="text-center bg-white/60 rounded-lg p-3">
-              <Apple className="w-5 h-5 mx-auto mb-1 text-blue-600" />
+              <Apple className="w-5 h-5 mx-auto mb-1 text-purple-600" />
               <p className="text-lg font-bold text-gray-900">{Math.round(totalNutrition.protein)}</p>
               <p className="text-xs text-gray-600">Prot</p>
             </div>
@@ -124,7 +124,7 @@ const TodayMeals = () => {
                         <span className="text-sm text-gray-500">({meal.time})</span>
                       )}
                     </div>
-                    <span className="text-sm font-semibold text-green-600">
+                    <span className="text-sm font-semibold text-purple-600">
                       {Math.round(nutrition.calories)} kcal
                     </span>
                   </div>
@@ -151,7 +151,7 @@ const TodayMeals = () => {
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
             <Button 
               asChild 
-              className="w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold shadow-lg"
+              className="w-full bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white font-semibold shadow-lg"
             >
               <Link to="/nutrition/diary">Ver diário completo</Link>
             </Button>

--- a/src/components/dashboard/TodayWorkout.tsx
+++ b/src/components/dashboard/TodayWorkout.tsx
@@ -33,7 +33,7 @@ const TodayWorkout = () => {
             </div>
             <h3 className="text-lg font-semibold text-gray-700 mb-2">Dia de Descanso</h3>
             <p className="text-gray-500 mb-4">Nenhum treino programado para hoje</p>
-            <Button asChild variant="outline" className="hover:bg-blue-50 hover:text-blue-600 border-blue-200">
+            <Button asChild variant="outline" className="hover:bg-purple-50 hover:text-purple-600 border-purple-200">
               <Link to="/workout/planning">Ver planejamento semanal</Link>
             </Button>
           </CardContent>
@@ -51,8 +51,8 @@ const TodayWorkout = () => {
       <Card className={`
         border hover:shadow-xl transition-all duration-300
         ${isComplete 
-          ? 'bg-gradient-to-br from-green-50 to-emerald-50 border-green-200' 
-          : 'bg-gradient-to-br from-blue-50 to-indigo-50 border-blue-200'
+          ? 'bg-gradient-to-br from-purple-50 to-purple-50 border-purple-200' 
+          : 'bg-gradient-to-br from-purple-50 to-purple-50 border-purple-200'
         }
       `}>
         <CardHeader className="pb-3">
@@ -61,8 +61,8 @@ const TodayWorkout = () => {
               <div className={`
                 w-10 h-10 rounded-xl flex items-center justify-center
                 ${isComplete 
-                  ? 'bg-gradient-to-br from-green-500 to-emerald-600' 
-                  : 'bg-gradient-to-br from-blue-500 to-indigo-600'
+                  ? 'bg-gradient-to-br from-purple-500 to-purple-600' 
+                  : 'bg-gradient-to-br from-purple-500 to-purple-600'
                 }
               `}>
                 <Dumbbell size={20} className="text-white" />
@@ -78,7 +78,7 @@ const TodayWorkout = () => {
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="flex items-center bg-green-500 text-white px-3 py-1 rounded-full"
+                className="flex items-center bg-purple-500 text-white px-3 py-1 rounded-full"
               >
                 <CheckCircle size={16} className="mr-1" />
                 <span className="text-sm font-medium">Concluído</span>
@@ -92,7 +92,7 @@ const TodayWorkout = () => {
           <div className="grid grid-cols-3 gap-4 mb-6">
             <div className="text-center">
               <div className="bg-white/60 rounded-lg p-3">
-                <Target className="w-5 h-5 mx-auto mb-1 text-blue-600" />
+                <Target className="w-5 h-5 mx-auto mb-1 text-purple-600" />
                 <p className="text-lg font-bold text-gray-900">{todayWorkout.exercises.length}</p>
                 <p className="text-xs text-gray-600">Exercícios</p>
               </div>
@@ -150,8 +150,8 @@ const TodayWorkout = () => {
               className={`
                 w-full text-white font-semibold shadow-lg
                 ${isComplete
-                  ? 'bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700'
-                  : 'bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700'
+                  ? 'bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700'
+                  : 'bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700'
                 }
               `}
             >

--- a/src/components/dashboard/WeeklyCalendar.tsx
+++ b/src/components/dashboard/WeeklyCalendar.tsx
@@ -41,7 +41,7 @@ const WeeklyCalendar = () => {
     >
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center">
-          <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center mr-3">
+          <div className="w-10 h-10 bg-gradient-to-br from-purple-500 to-purple-600 rounded-lg flex items-center justify-center mr-3">
             <Calendar className="text-white" size={20} />
           </div>
           <div>
@@ -61,7 +61,7 @@ const WeeklyCalendar = () => {
             className={`
               relative p-4 rounded-xl text-center cursor-pointer transition-all duration-200
               ${day.isToday 
-                ? 'bg-gradient-to-br from-blue-500 to-purple-600 text-white shadow-lg scale-105' 
+                ? 'bg-gradient-to-br from-purple-500 to-purple-600 text-white shadow-lg scale-105' 
                 : 'bg-gray-50 hover:bg-gray-100 hover:scale-105'
               }
             `}
@@ -80,7 +80,7 @@ const WeeklyCalendar = () => {
                   transition={{ delay: 0.3 + index * 0.1 }}
                   className={`
                     p-1 rounded-full 
-                    ${day.isToday ? 'bg-white/30' : 'bg-blue-500'}
+                    ${day.isToday ? 'bg-white/30' : 'bg-purple-500'}
                   `}
                 >
                   <Dumbbell size={12} className={day.isToday ? 'text-white' : 'text-white'} />
@@ -93,7 +93,7 @@ const WeeklyCalendar = () => {
                   transition={{ delay: 0.4 + index * 0.1 }}
                   className={`
                     p-1 rounded-full 
-                    ${day.isToday ? 'bg-white/30' : 'bg-green-500'}
+                    ${day.isToday ? 'bg-white/30' : 'bg-purple-500'}
                   `}
                 >
                   <Utensils size={12} className={day.isToday ? 'text-white' : 'text-white'} />
@@ -103,7 +103,7 @@ const WeeklyCalendar = () => {
 
             {/* Glow effect para hoje */}
             {day.isToday && (
-              <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl opacity-20 blur-xl -z-10"></div>
+              <div className="absolute inset-0 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl opacity-20 blur-xl -z-10"></div>
             )}
           </motion.div>
         ))}
@@ -116,13 +116,13 @@ const WeeklyCalendar = () => {
         transition={{ delay: 0.8 }}
         className="flex justify-center mt-6 space-x-6"
       >
-        <div className="flex items-center bg-blue-50 px-3 py-2 rounded-full">
-          <Dumbbell size={14} className="text-blue-600 mr-2" />
-          <span className="text-sm font-medium text-blue-700">Treino</span>
+        <div className="flex items-center bg-purple-50 px-3 py-2 rounded-full">
+          <Dumbbell size={14} className="text-purple-600 mr-2" />
+          <span className="text-sm font-medium text-purple-700">Treino</span>
         </div>
-        <div className="flex items-center bg-green-50 px-3 py-2 rounded-full">
-          <Utensils size={14} className="text-green-600 mr-2" />
-          <span className="text-sm font-medium text-green-700">Refeição</span>
+        <div className="flex items-center bg-purple-50 px-3 py-2 rounded-full">
+          <Utensils size={14} className="text-purple-600 mr-2" />
+          <span className="text-sm font-medium text-purple-700">Refeição</span>
         </div>
       </motion.div>
     </motion.div>

--- a/src/components/dashboard/WeeklyWorkoutProgress.tsx
+++ b/src/components/dashboard/WeeklyWorkoutProgress.tsx
@@ -74,7 +74,7 @@ const WeeklyWorkoutProgress = () => {
         </p>
         
         {weeklyStats.percentComplete >= 100 && (
-          <div className="mt-3 bg-green-50 p-3 rounded-md border border-green-100 text-green-800 text-sm">
+          <div className="mt-3 bg-purple-50 p-3 rounded-md border border-purple-100 text-purple-800 text-sm">
             Você alcançou 100% da sua meta semanal! Continue mantendo o ritmo!
           </div>
         )}

--- a/src/components/feedback/UserFeedbackForm.tsx
+++ b/src/components/feedback/UserFeedbackForm.tsx
@@ -79,7 +79,7 @@ const UserFeedbackForm = () => {
       <Card className="bg-white rounded-lg shadow">
         <CardContent className="pt-6 text-center">
           <div className="mb-4">
-            <Smile className="mx-auto h-12 w-12 text-green-500" />
+            <Smile className="mx-auto h-12 w-12 text-purple-500" />
           </div>
           <h3 className="text-xl font-bold mb-2">Obrigado pelo feedback!</h3>
           <p className="text-gray-600 mb-6">
@@ -155,7 +155,7 @@ const UserFeedbackForm = () => {
                 type="button"
                 variant={feedbackType === 'positive' ? 'default' : 'outline'}
                 className={`flex flex-col items-center p-4 ${
-                  feedbackType === 'positive' ? 'bg-green-500 hover:bg-green-600' : ''
+                  feedbackType === 'positive' ? 'bg-purple-500 hover:bg-purple-600' : ''
                 }`}
                 onClick={() => setFeedbackType('positive')}
                 disabled={isSubmitting}

--- a/src/components/gamification/UserAchievements.tsx
+++ b/src/components/gamification/UserAchievements.tsx
@@ -28,7 +28,7 @@ const UserAchievements = () => {
     if (mealPlans.length >= 3) {
       titles.push({
         name: "Nutricionista da Própria Vida",
-        icon: <Award className="h-5 w-5 text-blue-500" />
+        icon: <Award className="h-5 w-5 text-purple-500" />
       });
     }
     

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Bell, Menu, X, User, Settings, LogOut, Zap, Brain } from 'lucide-react';
+import { Bell, Menu, X, User, Settings, Zap, Brain, LayoutDashboard, Dumbbell, Utensils, LineChart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAppContext } from '@/context/AppContext';
 import { Badge } from '@/components/ui/badge';
@@ -19,7 +19,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { motion, AnimatePresence } from 'framer-motion';
 
 const Navbar = () => {
   const { notifications, user } = useAppContext();
@@ -40,11 +39,11 @@ const Navbar = () => {
   }, []);
 
   const navLinks = [
-    { to: "/dashboard", label: "Dashboard", icon: "📊" },
-    { to: "/workout/planning", label: "Treinos", icon: "💪" },
-    { to: "/nutrition/planning", label: "Nutrição", icon: "🥗" },
-    { to: "/progress", label: "Progresso", icon: "📈" },
-    { to: "/ai/assistant", label: "IA", icon: "🧠" }
+    { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+    { to: "/workout/planning", label: "Treinos", icon: Dumbbell },
+    { to: "/nutrition/planning", label: "Nutrição", icon: Utensils },
+    { to: "/progress", label: "Progresso", icon: LineChart },
+    { to: "/ai/assistant", label: "IA", icon: Brain }
   ];
 
   const isActivePath = (path: string) => {
@@ -55,114 +54,91 @@ const Navbar = () => {
   };
 
   return (
-    <motion.nav 
-      initial={{ y: -100 }}
-      animate={{ y: 0 }}
-      transition={{ duration: 0.3 }}
+    <nav
       className={`
         sticky top-0 z-50 transition-all duration-300 backdrop-blur-lg
-        ${scrolled 
-          ? 'bg-white/90 shadow-lg border-b border-gray-200/50' 
+        ${scrolled
+          ? 'bg-white/90 shadow-lg border-b border-gray-200/50'
           : 'bg-white/95 border-b border-gray-100'
         }
       `}
     >
       <div className="container mx-auto h-16 px-4">
         <div className="flex justify-between items-center h-full">
-          {/* Logo com gradiente moderno */}
-          <motion.div 
-            className="flex items-center"
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-          >
+          {/* Logo */}
+          <div className="flex items-center">
             <Link to="/dashboard" className="flex items-center space-x-2 group">
               <div className="relative">
-                <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg flex items-center justify-center shadow-lg group-hover:shadow-xl transition-shadow">
+                <div className="w-8 h-8 bg-gradient-to-br from-purple-500 to-purple-700 rounded-lg flex items-center justify-center shadow-lg">
                   <Zap className="w-5 h-5 text-white" />
                 </div>
-                <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg opacity-0 group-hover:opacity-20 transition-opacity blur-xl"></div>
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-purple-500 to-purple-700 bg-clip-text text-transparent">
                 ForgeNFuel
               </span>
             </Link>
-            
+
             {/* Links de navegação - Desktop */}
             <div className="hidden lg:flex ml-12 space-x-1">
               {navLinks.map((link) => (
-                <motion.div key={link.to} whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                  <Link 
-                    to={link.to}
-                    className={`
-                      px-4 py-2 rounded-lg font-medium transition-all duration-200 flex items-center space-x-2
-                      ${isActivePath(link.to)
-                        ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg' 
-                        : 'text-gray-700 hover:text-blue-600 hover:bg-blue-50'
-                      }
-                    `}
-                  >
-                    <span>{link.icon}</span>
-                    <span>{link.label}</span>
-                  </Link>
-                </motion.div>
+                <Link
+                  key={link.to}
+                  to={link.to}
+                  className={`px-4 py-2 rounded-lg font-medium transition-colors flex items-center space-x-2 ${
+                    isActivePath(link.to)
+                      ? 'bg-gradient-to-r from-purple-500 to-purple-700 text-white shadow-lg'
+                      : 'text-gray-700 hover:text-purple-600 hover:bg-purple-50'
+                  }`}
+                >
+                  <link.icon className="w-4 h-4" />
+                  <span>{link.label}</span>
+                </Link>
               ))}
             </div>
-          </motion.div>
+          </div>
           
           {/* Ações do usuário */}
           <div className="flex items-center space-x-3">
-            {/* Notificações com animação */}
-            <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+            <div>
               <Link to="/notifications">
-                <Button 
-                  variant="ghost" 
-                  size="icon" 
-                  className="relative hover:bg-blue-50 rounded-full transition-colors"
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="relative hover:bg-purple-50 rounded-full transition-colors"
                 >
                   <Bell size={20} className="text-gray-600" />
-                  <AnimatePresence>
-                    {unreadCount > 0 && (
-                      <motion.div
-                        initial={{ scale: 0, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0, opacity: 0 }}
-                        transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                      >
-                        <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 bg-gradient-to-r from-red-500 to-pink-500 border-0 text-xs font-bold animate-pulse">
-                          {unreadCount > 9 ? '9+' : unreadCount}
-                        </Badge>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                  {unreadCount > 0 && (
+                    <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 bg-purple-600 text-white border-0 text-xs font-bold">
+                      {unreadCount > 9 ? '9+' : unreadCount}
+                    </Badge>
+                  )}
                 </Button>
               </Link>
-            </motion.div>
+            </div>
             
             {/* Menu do usuário - Desktop */}
             <div className="hidden md:block">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <motion.button 
-                    whileHover={{ scale: 1.05 }} 
-                    whileTap={{ scale: 0.95 }}
-                    className="flex items-center space-x-2 p-2 rounded-full hover:bg-gray-100 transition-colors group"
+                  <button
+                    className="flex items-center space-x-2 p-2 rounded-full hover:bg-purple-50 transition-colors group"
+                    type="button"
                   >
-                    <div className="relative">
-                      <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-semibold shadow-lg group-hover:shadow-xl transition-shadow">
+                    <div>
+                      <div className="w-10 h-10 bg-purple-600 rounded-full flex items-center justify-center text-white font-semibold ring-2 ring-purple-300">
                         {user?.name?.charAt(0) || 'U'}
                       </div>
-                      <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full opacity-0 group-hover:opacity-30 transition-opacity blur-lg"></div>
                     </div>
                     <div className="hidden lg:block text-left">
                       <p className="text-sm font-medium text-gray-900">{user?.name || 'Usuário'}</p>
                       <p className="text-xs text-gray-500">Ver perfil</p>
                     </div>
-                  </motion.button>
+                  </button>
                 </DropdownMenuTrigger>
                 
                 <DropdownMenuContent align="end" className="w-56 bg-white/95 backdrop-blur-lg border border-gray-200/50 shadow-xl">
                   <DropdownMenuLabel className="flex items-center space-x-3">
-                    <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white text-sm font-semibold">
+                    <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center text-white text-sm font-semibold">
                       {user?.name?.charAt(0) || 'U'}
                     </div>
                     <div>
@@ -190,7 +166,6 @@ const Navbar = () => {
                   <DropdownMenuSeparator />
                   
                   <DropdownMenuItem className="flex items-center space-x-2 text-red-600 focus:text-red-600 focus:bg-red-50">
-                    <LogOut className="w-4 h-4" />
                     <LogoutButton className="p-0 h-auto font-normal justify-start text-red-600 hover:text-red-600 hover:bg-transparent" />
                   </DropdownMenuItem>
                 </DropdownMenuContent>
@@ -201,23 +176,16 @@ const Navbar = () => {
             <div className="md:hidden">
               <Sheet open={isOpen} onOpenChange={setIsOpen}>
                 <SheetTrigger asChild>
-                  <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                    <Button variant="ghost" size="icon" className="rounded-full">
-                      <Menu size={24} />
-                    </Button>
-                  </motion.div>
+                  <Button variant="ghost" size="icon" className="rounded-full">
+                    <Menu size={24} />
+                  </Button>
                 </SheetTrigger>
-                
+
                 <SheetContent side="right" className="w-[280px] bg-white/95 backdrop-blur-lg border-l border-gray-200/50">
-                  <motion.div 
-                    initial={{ opacity: 0, x: 20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ duration: 0.2 }}
-                    className="flex flex-col h-full"
-                  >
+                  <div className="flex flex-col h-full">
                     {/* Header do menu mobile */}
                     <div className="flex items-center justify-between py-4 border-b border-gray-200">
-                      <h2 className="text-lg font-semibold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+                      <h2 className="text-lg font-semibold bg-gradient-to-r from-purple-500 to-purple-700 bg-clip-text text-transparent">
                         Menu
                       </h2>
                       <SheetClose asChild>
@@ -226,82 +194,62 @@ const Navbar = () => {
                         </Button>
                       </SheetClose>
                     </div>
-                    
+
                     <div className="flex-1 py-6 space-y-6">
                       {/* Perfil do usuário no mobile */}
-                      <motion.div 
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.1 }}
-                        className="flex items-center space-x-3 p-4 rounded-xl bg-gradient-to-r from-blue-50 to-purple-50"
-                      >
-                        <div className="relative">
-                          <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-semibold shadow-lg">
+                      <div className="flex items-center space-x-3 p-4 rounded-xl bg-purple-50">
+                        <div>
+                          <div className="w-12 h-12 bg-purple-600 rounded-full flex items-center justify-center text-white font-semibold ring-2 ring-purple-300">
                             {user?.name?.charAt(0) || 'U'}
                           </div>
-                          <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full opacity-30 blur-lg"></div>
                         </div>
                         <div className="flex-1">
                           <p className="font-medium text-gray-900">{user?.name || 'Usuário'}</p>
                           <SheetClose asChild>
-                            <Link to="/profile" className="text-sm text-blue-600 hover:text-blue-700">
+                            <Link to="/profile" className="text-sm text-purple-600 hover:text-purple-700">
                               Ver perfil →
                             </Link>
                           </SheetClose>
                         </div>
-                      </motion.div>
-                      
+                      </div>
+
                       {/* Links de navegação no mobile */}
                       <div className="space-y-2">
-                        {navLinks.map((link, index) => (
-                          <motion.div
-                            key={link.to}
-                            initial={{ opacity: 0, x: 20 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{ delay: 0.1 + index * 0.05 }}
-                          >
-                            <SheetClose asChild>
-                              <Link 
-                                to={link.to}
-                                className={`
-                                  flex items-center space-x-3 px-4 py-3 rounded-xl font-medium transition-all duration-200
-                                  ${isActivePath(link.to)
-                                    ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg' 
-                                    : 'text-gray-700 hover:bg-gray-100'
-                                  }
-                                `}
-                                onClick={() => setIsOpen(false)}
-                              >
-                                <span className="text-xl">{link.icon}</span>
-                                <span>{link.label}</span>
-                              </Link>
-                            </SheetClose>
-                          </motion.div>
+                        {navLinks.map((link) => (
+                          <SheetClose asChild key={link.to}>
+                            <Link
+                              to={link.to}
+                              className={`flex items-center space-x-3 px-4 py-3 rounded-xl font-medium transition-colors ${
+                                isActivePath(link.to)
+                                  ? 'bg-gradient-to-r from-purple-500 to-purple-700 text-white shadow-lg'
+                                  : 'text-gray-700 hover:bg-gray-100'
+                              }`}
+                              onClick={() => setIsOpen(false)}
+                            >
+                              <link.icon className="w-5 h-5" />
+                              <span>{link.label}</span>
+                            </Link>
+                          </SheetClose>
                         ))}
                       </div>
                     </div>
-                    
+
                     {/* Footer do menu mobile */}
-                    <motion.div 
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.3 }}
-                      className="border-t border-gray-200 pt-4"
-                    >
+                    <div className="border-t border-gray-200 pt-4">
                       <SheetClose asChild>
                         <div onClick={() => setIsOpen(false)}>
                           <LogoutButton className="w-full bg-gradient-to-r from-red-500 to-pink-500 hover:from-red-600 hover:to-pink-600 text-white border-0 shadow-lg" />
                         </div>
                       </SheetClose>
-                    </motion.div>
-                  </motion.div>
+                    </div>
+                  </div>
                 </SheetContent>
               </Sheet>
             </div>
           </div>
         </div>
       </div>
-    </motion.nav>
+    </nav>
   );
 };
 

--- a/src/components/progress/ExerciseProgressChart.tsx
+++ b/src/components/progress/ExerciseProgressChart.tsx
@@ -87,16 +87,16 @@ const ExerciseProgressChart = () => {
         </div>
         
         <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
-          <div className="text-center p-2 bg-blue-50 rounded">
+          <div className="text-center p-2 bg-purple-50 rounded">
             <p className="text-gray-600">Progresso Total</p>
-            <p className="font-bold text-blue-600">
+            <p className="font-bold text-purple-600">
               +{progressData.length > 0 ? 
                 (progressData[progressData.length - 1].weight - progressData[0].weight) : 0}kg
             </p>
           </div>
-          <div className="text-center p-2 bg-green-50 rounded">
+          <div className="text-center p-2 bg-purple-50 rounded">
             <p className="text-gray-600">Sessões</p>
-            <p className="font-bold text-green-600">{progressData.length}</p>
+            <p className="font-bold text-purple-600">{progressData.length}</p>
           </div>
         </div>
       </CardContent>

--- a/src/components/tracking/DeviceMonitoring.tsx
+++ b/src/components/tracking/DeviceMonitoring.tsx
@@ -94,7 +94,7 @@ const DeviceMonitoring = () => {
           
           <div className="bg-gray-50 p-3 rounded-lg border border-gray-100">
             <div className="flex items-center text-sm text-gray-600 mb-1">
-              <Activity className="mr-1 h-4 w-4 text-green-500" />
+              <Activity className="mr-1 h-4 w-4 text-purple-500" />
               <span>Calorias</span>
             </div>
             <div className="text-xl font-bold">{monitoringData.caloriesBurned} <span className="text-sm font-normal">kcal</span></div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
         achievement:
           "border-yellow-200 bg-yellow-100 text-yellow-800 hover:bg-yellow-200",
         progress:
-          "border-green-200 bg-green-100 text-green-800 hover:bg-green-200",
+          "border-purple-200 bg-purple-100 text-purple-800 hover:bg-purple-200",
         fitness:
           "border-fitness-primary/20 bg-fitness-primary/10 text-fitness-primary hover:bg-fitness-primary/20",
       },

--- a/src/components/workout/WorkoutExecution.tsx
+++ b/src/components/workout/WorkoutExecution.tsx
@@ -73,7 +73,7 @@ const WorkoutExecution: React.FC<WorkoutExecutionProps> = ({ workout, onComplete
       
       <div className="space-y-4">
         {workout.exercises.map((exercise, index) => (
-          <Card key={index} className={`border ${completedExercises[index] ? 'border-green-500 bg-green-50' : ''}`}>
+          <Card key={index} className={`border ${completedExercises[index] ? 'border-purple-500 bg-purple-50' : ''}`}>
             <CardContent className="p-4">
               <div 
                 className="flex justify-between items-center cursor-pointer"
@@ -81,7 +81,7 @@ const WorkoutExecution: React.FC<WorkoutExecutionProps> = ({ workout, onComplete
               >
                 <div className="flex items-center">
                   {completedExercises[index] && (
-                    <CheckCircle className="text-green-500 mr-2" size={18} />
+                    <CheckCircle className="text-purple-500 mr-2" size={18} />
                   )}
                   <h3 className="font-medium">{exercise.name}</h3>
                 </div>
@@ -137,7 +137,7 @@ const WorkoutExecution: React.FC<WorkoutExecutionProps> = ({ workout, onComplete
                   
                   <Button 
                     onClick={() => handleCompleteExercise(index)}
-                    className="w-full bg-green-500 hover:bg-green-600"
+                    className="w-full bg-purple-500 hover:bg-purple-600"
                     disabled={completedExercises[index]}
                   >
                     {completedExercises[index] ? 'Exercício Completo' : 'Marcar como Completo'}

--- a/src/index.css
+++ b/src/index.css
@@ -14,35 +14,35 @@
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
 
-    --primary: 196 80% 59%;
+    --primary: 270 80% 60%;
     --primary-foreground: 210 40% 98%;
 
-    --secondary: 142 70% 45%;
+    --secondary: 270 70% 50%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 270 30% 96%;
+    --muted-foreground: 270 15% 47%;
 
-    --accent: 217 91% 60%;
+    --accent: 270 90% 65%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 196 80% 59%;
+    --border: 270 20% 90%;
+    --input: 270 20% 90%;
+    --ring: 270 80% 60%;
 
     --radius: 0.5rem;
 
     --sidebar-background: 0 0% 100%;
     --sidebar-foreground: 222.2 84% 4.9%;
-    --sidebar-primary: 196 80% 59%;
+    --sidebar-primary: 270 80% 60%;
     --sidebar-primary-foreground: 210 40% 98%;
-    --sidebar-accent: 210 40% 96.1%;
+    --sidebar-accent: 270 40% 96%;
     --sidebar-accent-foreground: 222.2 47.4% 11.2%;
-    --sidebar-border: 214.3 31.8% 91.4%;
-    --sidebar-ring: 196 80% 59%;
+    --sidebar-border: 270 20% 90%;
+    --sidebar-ring: 270 80% 60%;
   }
 
   .dark {
@@ -55,33 +55,33 @@
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 196 80% 59%;
+    --primary: 270 80% 60%;
     --primary-foreground: 222.2 47.4% 11.2%;
 
-    --secondary: 142 70% 45%;
+    --secondary: 270 70% 50%;
     --secondary-foreground: 222.2 47.4% 11.2%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 270 32% 18%;
+    --muted-foreground: 270 20% 65%;
 
-    --accent: 217 91% 60%;
+    --accent: 270 90% 65%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    
+    --border: 270 32% 18%;
+    --input: 270 32% 18%;
+    --ring: 270 60% 70%;
+
     --sidebar-background: 222.2 84% 4.9%;
     --sidebar-foreground: 210 40% 98%;
-    --sidebar-primary: 196 80% 59%;
+    --sidebar-primary: 270 80% 60%;
     --sidebar-primary-foreground: 222.2 47.4% 11.2%;
-    --sidebar-accent: 217.2 32.6% 17.5%;
+    --sidebar-accent: 270 32% 18%;
     --sidebar-accent-foreground: 210 40% 98%;
-    --sidebar-border: 217.2 32.6% 17.5%;
-    --sidebar-ring: 212.7 26.8% 83.9%;
+    --sidebar-border: 270 32% 18%;
+    --sidebar-ring: 270 60% 70%;
   }
 }
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -16,7 +16,7 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <a href="/" className="text-purple-500 hover:text-purple-700 underline">
           Return to Home
         </a>
       </div>

--- a/src/pages/notifications/NotificationCenter.tsx
+++ b/src/pages/notifications/NotificationCenter.tsx
@@ -115,7 +115,7 @@ const NotificationCenter = () => {
                         <div
                           key={notification.id}
                           className={`p-4 border-b last:border-b-0 ${
-                            notification.read ? 'bg-white' : 'bg-blue-50'
+                            notification.read ? 'bg-white' : 'bg-purple-50'
                           }`}
                         >
                           <div className="flex items-start">
@@ -172,7 +172,7 @@ const NotificationCenter = () => {
                   <div
                     key={notification.id}
                     className={`p-4 border-b last:border-b-0 ${
-                      notification.read ? 'bg-white' : 'bg-blue-50'
+                      notification.read ? 'bg-white' : 'bg-purple-50'
                     }`}
                   >
                     <div className="flex items-start">
@@ -222,7 +222,7 @@ const NotificationCenter = () => {
                   <div
                     key={notification.id}
                     className={`p-4 border-b last:border-b-0 ${
-                      notification.read ? 'bg-white' : 'bg-blue-50'
+                      notification.read ? 'bg-white' : 'bg-purple-50'
                     }`}
                   >
                     <div className="flex items-start">
@@ -272,12 +272,12 @@ const NotificationCenter = () => {
                   <div
                     key={notification.id}
                     className={`p-4 border-b last:border-b-0 ${
-                      notification.read ? 'bg-white' : 'bg-blue-50'
+                      notification.read ? 'bg-white' : 'bg-purple-50'
                     }`}
                   >
                     <div className="flex items-start">
                       <div className="mr-3 mt-0.5">
-                        <span className="text-blue-500">📢</span>
+                        <span className="text-purple-500">📢</span>
                       </div>
                       <div className="flex-1">
                         <p>{notification.message}</p>

--- a/src/pages/nutrition/FoodDiary.tsx
+++ b/src/pages/nutrition/FoodDiary.tsx
@@ -204,7 +204,7 @@ const FoodDiary = () => {
                   </div>
                   <Progress value={percentages.protein} className="h-2 bg-gray-200">
                     <div 
-                      className="h-full bg-blue-500" 
+                      className="h-full bg-purple-500" 
                       style={{ width: `${percentages.protein}%` }}
                     ></div>
                   </Progress>
@@ -244,7 +244,7 @@ const FoodDiary = () => {
                   <h3 className="font-medium mb-2">Distribuição de Macronutrientes</h3>
                   <div className="flex h-4 rounded-md overflow-hidden mb-2">
                     <div 
-                      className="bg-blue-500" 
+                      className="bg-purple-500" 
                       style={{ width: `${consumed.protein * 4 / (consumed.protein * 4 + consumed.carbs * 4 + consumed.fat * 9) * 100 || 0}%` }}
                     ></div>
                     <div 
@@ -258,7 +258,7 @@ const FoodDiary = () => {
                   </div>
                   <div className="grid grid-cols-3 text-xs text-center">
                     <div>
-                      <div className="w-3 h-3 bg-blue-500 rounded-full mx-auto mb-1"></div>
+                      <div className="w-3 h-3 bg-purple-500 rounded-full mx-auto mb-1"></div>
                       <p>Proteína</p>
                     </div>
                     <div>

--- a/src/pages/nutrition/MealPlanning.tsx
+++ b/src/pages/nutrition/MealPlanning.tsx
@@ -327,7 +327,7 @@ const MealPlanning: React.FC = () => {
                                     size="icon"
                                     onClick={() => handleEditMealPlan(mealPlan)}
                                     title="Editar plano"
-                                    className="hover:bg-blue-50 hover:text-blue-600 transition-colors"
+                                    className="hover:bg-purple-50 hover:text-purple-600 transition-colors"
                                   >
                                     <Edit className="h-4 w-4" />
                                   </Button>

--- a/src/pages/progress/ProgressDashboard.tsx
+++ b/src/pages/progress/ProgressDashboard.tsx
@@ -234,7 +234,7 @@ const ProgressDashboard = () => {
                           <div className="text-right">
                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                               log.completed 
-                                ? 'bg-green-100 text-green-800' 
+                                ? 'bg-purple-100 text-purple-800' 
                                 : 'bg-amber-100 text-amber-800'
                             }`}>
                               {log.completed ? 'Concluído' : 'Incompleto'}
@@ -280,29 +280,29 @@ const ProgressDashboard = () => {
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div className="border rounded-lg p-4 text-center">
                       <p className="text-sm text-gray-500 mb-2">Proteínas</p>
-                      <p className="text-2xl font-bold text-blue-600 mb-1">25%</p>
+                      <p className="text-2xl font-bold text-purple-600 mb-1">25%</p>
                       <p className="text-xs text-gray-500">Ideal: 25-35%</p>
-                      <div className="mt-2 text-xs text-green-600">✓ Dentro da meta</div>
+                      <div className="mt-2 text-xs text-purple-600">✓ Dentro da meta</div>
                     </div>
                     
                     <div className="border rounded-lg p-4 text-center">
                       <p className="text-sm text-gray-500 mb-2">Carboidratos</p>
                       <p className="text-2xl font-bold text-yellow-600 mb-1">50%</p>
                       <p className="text-xs text-gray-500">Ideal: 45-55%</p>
-                      <div className="mt-2 text-xs text-green-600">✓ Dentro da meta</div>
+                      <div className="mt-2 text-xs text-purple-600">✓ Dentro da meta</div>
                     </div>
                     
                     <div className="border rounded-lg p-4 text-center">
                       <p className="text-sm text-gray-500 mb-2">Gorduras</p>
                       <p className="text-2xl font-bold text-red-600 mb-1">25%</p>
                       <p className="text-xs text-gray-500">Ideal: 20-30%</p>
-                      <div className="mt-2 text-xs text-green-600">✓ Dentro da meta</div>
+                      <div className="mt-2 text-xs text-purple-600">✓ Dentro da meta</div>
                     </div>
                   </div>
                   
-                  <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-                    <h4 className="font-medium text-blue-900 mb-2">Recomendações</h4>
-                    <ul className="text-sm text-blue-800 space-y-1">
+                  <div className="mt-6 p-4 bg-purple-50 rounded-lg">
+                    <h4 className="font-medium text-purple-900 mb-2">Recomendações</h4>
+                    <ul className="text-sm text-purple-800 space-y-1">
                       <li>• Sua distribuição de macronutrientes está equilibrada</li>
                       <li>• Continue mantendo o consumo de proteínas para preservar massa muscular</li>
                       <li>• Considere ajustar as porções conforme seus objetivos de treino</li>

--- a/src/pages/user/FeedbackPage.tsx
+++ b/src/pages/user/FeedbackPage.tsx
@@ -30,21 +30,21 @@ const FeedbackPage = () => {
               
               <div className="space-y-4 text-sm">
                 <div className="flex items-start">
-                  <div className="bg-blue-100 text-blue-800 rounded-full p-1 mr-2">
+                  <div className="bg-purple-100 text-purple-800 rounded-full p-1 mr-2">
                     <span className="block h-5 w-5 rounded-full text-center">1</span>
                   </div>
                   <p>Analisamos cada feedback individualmente</p>
                 </div>
                 
                 <div className="flex items-start">
-                  <div className="bg-blue-100 text-blue-800 rounded-full p-1 mr-2">
+                  <div className="bg-purple-100 text-purple-800 rounded-full p-1 mr-2">
                     <span className="block h-5 w-5 rounded-full text-center">2</span>
                   </div>
                   <p>Priorizamos as funcionalidades mais solicitadas</p>
                 </div>
                 
                 <div className="flex items-start">
-                  <div className="bg-blue-100 text-blue-800 rounded-full p-1 mr-2">
+                  <div className="bg-purple-100 text-purple-800 rounded-full p-1 mr-2">
                     <span className="block h-5 w-5 rounded-full text-center">3</span>
                   </div>
                   <p>Implementamos melhorias em cada atualização</p>

--- a/src/pages/user/ProfileSettings.tsx
+++ b/src/pages/user/ProfileSettings.tsx
@@ -240,7 +240,7 @@ const ProfileSettings = () => {
                     <h3 className="font-medium mb-2">Distribuição de Macronutrientes</h3>
                     <div className="flex h-4 rounded-md overflow-hidden mb-2">
                       <div 
-                        className="bg-blue-500" 
+                        className="bg-purple-500" 
                         style={{ width: `${nutritionGoals.protein * 4 / (nutritionGoals.protein * 4 + nutritionGoals.carbs * 4 + nutritionGoals.fat * 9) * 100}%` }}
                       ></div>
                       <div 

--- a/src/pages/workout/WorkoutPlanning.tsx
+++ b/src/pages/workout/WorkoutPlanning.tsx
@@ -229,14 +229,14 @@ const WorkoutPlanning = () => {
                                       animate={{ opacity: 1 }}
                                       className={`border rounded-lg p-4 ${
                                         isCompleted 
-                                          ? 'border-green-500 bg-green-50' 
+                                          ? 'border-purple-500 bg-purple-50' 
                                           : 'border-gray-200 hover:border-fitness-primary transition-colors'
                                       }`}
                                     >
                                       <div className="flex justify-between items-start mb-2">
                                         <h3 className="font-medium text-gray-900 truncate">{workout.name}</h3>
                                         {isCompleted && (
-                                          <CheckCircle size={16} className="text-green-500 ml-2" />
+                                          <CheckCircle size={16} className="text-purple-500 ml-2" />
                                         )}
                                       </div>
                                       
@@ -272,7 +272,7 @@ const WorkoutPlanning = () => {
                                           variant="ghost"
                                           size="icon"
                                           onClick={() => handleEditWorkout(workout)}
-                                          className="hover:bg-blue-50 hover:text-blue-600"
+                                          className="hover:bg-purple-50 hover:text-purple-600"
                                         >
                                           <Edit size={14} />
                                         </Button>
@@ -439,7 +439,7 @@ const WorkoutPlanning = () => {
                             )}
                             {exercise.isPublic && (
                               <div className="mt-2">
-                                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-green-100 text-green-800">
+                                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-purple-100 text-purple-800">
                                   Exercício Padrão
                                 </span>
                               </div>

--- a/src/pages/workout/WorkoutProgress.tsx
+++ b/src/pages/workout/WorkoutProgress.tsx
@@ -82,7 +82,7 @@ const WorkoutProgress = () => {
                   <div key={log.id} className="border rounded-md p-4">
                     <div className="flex justify-between mb-2">
                       <h3 className="font-semibold">{log.date}</h3>
-                      <span className={`px-2 py-1 rounded-full text-xs ${log.completed ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'}`}>
+                      <span className={`px-2 py-1 rounded-full text-xs ${log.completed ? 'bg-purple-100 text-purple-800' : 'bg-amber-100 text-amber-800'}`}>
                         {log.completed ? 'Concluído' : 'Parcial'}
                       </span>
                     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,13 +64,13 @@ export default {
 					border: 'hsl(var(--sidebar-border))',
 					ring: 'hsl(var(--sidebar-ring))'
 				},
-				fitness: {
-					primary: '#38bdf8',
-					secondary: '#22c55e',
-					accent: '#3b82f6',
-					background: '#f8fafc'
-				}
-			},
+                                fitness: {
+                                        primary: '#a855f7',
+                                        secondary: '#9333ea',
+                                        accent: '#c084fc',
+                                        background: '#f5f3ff'
+                                }
+                        },
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- simplify navigation bar by removing emojis and heavy animations
- switch app theme to a unified purple palette
- highlight profile controls and remove duplicate logout icon

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a69abdc7f48329ad48509f0a709232