### PR TITLE
Remove duplicate nutrition route registration

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -66,9 +66,6 @@ app.use('/api/nutrition', require('./routes/nutrition'));
 app.use('/api/progress', require('./routes/progress'));
 app.use('/api/ai', require('./routes/ai'));
 
-// Verificar se a rota de nutrição está registrada
-app.use('/api/nutrition', require('./routes/nutrition'));
-
 // Error handler
 app.use((err, req, res, next) => {
   console.error(err.stack);


### PR DESCRIPTION
## Summary
- remove redundant `/api/nutrition` route registration in backend server

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68adc69efaa08329b3a37d867938f393