### PR TITLE
Use production backend URL with dev fallback

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,10 @@
 // src/services/api.ts
 import axios from 'axios';
 
-const API_URL = 'http://localhost:5000/api';
+// Use local backend in development and production URL otherwise
+const API_URL = import.meta.env.DEV
+  ? 'http://localhost:5000/api'
+  : 'https://forgenfuel.onrender.com/api';
 const TOKEN_KEY = 'auth_token';
 
 export const getAuthToken = () => localStorage.getItem(TOKEN_KEY);


### PR DESCRIPTION
## Summary
- Switch API base URL to `https://forgenfuel.onrender.com` in production
- Keep local `http://localhost:5000` API when running in development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc9931a848329be0cdd7050ae9b22