### PR TITLE
feat: store AI meal plan

### DIFF
--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -90,16 +90,81 @@ router.post('/meal-plans', auth, async (req, res) => {
     const nutritionalGoals = user.nutritionGoals || {};
     
     // Gerar plano alimentar com a IA
-    const mealPlan = await generateMealPlan(userData, nutritionalGoals);
-    
+    const aiResponse = await generateMealPlan(userData, nutritionalGoals);
+
+    let parsedPlan;
+    try {
+      parsedPlan = JSON.parse(aiResponse);
+    } catch (parseError) {
+      console.error('Erro ao parsear plano alimentar da IA:', parseError);
+      return res.status(500).json({
+        success: false,
+        message: 'Formato de plano alimentar inválido retornado pela IA'
+      });
+    }
+
+    const storedPlan = await prisma.$transaction(async (tx) => {
+      const plan = await tx.mealPlan.create({
+        data: {
+          name: 'Plano Alimentar IA',
+          date: new Date().toISOString().split('T')[0],
+          userId: parseInt(userId)
+        }
+      });
+
+      for (const meal of parsedPlan.meals || []) {
+        const mealRecord = await tx.meal.create({
+          data: {
+            name: meal.name,
+            mealPlanId: plan.id
+          }
+        });
+
+        for (const item of meal.items || []) {
+          const food = await tx.food.create({
+            data: {
+              name: item.name,
+              weight: parseFloat(item.quantity) || 0,
+              calories: parseFloat(item.calories) || 0,
+              protein: parseFloat(item.protein) || 0,
+              carbs: parseFloat(item.carbs) || 0,
+              fat: parseFloat(item.fat) || 0,
+              userId: parseInt(userId)
+            }
+          });
+
+          await tx.mealFood.create({
+            data: {
+              mealId: mealRecord.id,
+              foodId: food.id,
+              quantity: 1
+            }
+          });
+        }
+      }
+
+      return tx.mealPlan.findUnique({
+        where: { id: plan.id },
+        include: {
+          meals: {
+            include: {
+              mealFoods: {
+                include: { food: true }
+              }
+            }
+          }
+        }
+      });
+    });
+
     res.json({
       success: true,
-      mealPlan
+      mealPlan: storedPlan
     });
   } catch (error) {
     console.error('Erro ao gerar plano alimentar:', error);
-    res.status(500).json({ 
-      success: false, 
+    res.status(500).json({
+      success: false,
       message: 'Erro ao gerar plano alimentar',
       error: error.message 
     });

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -93,7 +93,7 @@ async function generateWorkoutPlan(userData) {
 async function generateMealPlan(userData, nutritionalGoals) {
   const prompt = `
     Com base nas seguintes informações do usuário, crie um plano alimentar personalizado para um dia:
-    
+
     Informações do usuário:
     - Idade: ${userData.age || 'Não informada'} anos
     - Peso: ${userData.weight || 'Não informado'} kg
@@ -101,21 +101,38 @@ async function generateMealPlan(userData, nutritionalGoals) {
     - Objetivo: ${userData.goal || 'Não informado'}
     - Restrições alimentares: ${userData.dietaryRestrictions || 'Nenhuma informada'}
     - Preferências alimentares: ${userData.foodPreferences || 'Nenhuma informada'}
-    
+
     Metas nutricionais diárias:
     - Calorias: ${nutritionalGoals.calories || 'Não informado'} kcal
     - Proteínas: ${nutritionalGoals.protein || 'Não informado'} g
     - Carboidratos: ${nutritionalGoals.carbs || 'Não informado'} g
     - Gorduras: ${nutritionalGoals.fat || 'Não informado'} g
-    
-    Por favor, crie um plano alimentar para um dia com:
+
+    Gere um plano alimentar para um dia com:
     1. 3 refeições principais (café da manhã, almoço, jantar)
     2. 2 lanches
-    3. Detalhes nutricionais para cada refeição
-    4. Sugestões de alimentos específicos
-    5. Quantidades em gramas ou porções
-    
-    Formate a resposta como um plano alimentar estruturado, fácil de ler e seguir.
+    3. Detalhes nutricionais para cada alimento
+    4. Quantidades em gramas ou porções
+
+    Responda APENAS com JSON válido seguindo este formato:
+    {
+      "meals": [
+        {
+          "name": "Nome da refeição",
+          "items": [
+            {
+              "name": "Alimento",
+              "quantity": 0,
+              "calories": 0,
+              "protein": 0,
+              "carbs": 0,
+              "fat": 0
+            }
+          ]
+        }
+      ]
+    }
+    Não inclua nenhum texto fora do JSON.
   `;
 
   return await callOpenRouter(prompt, AI_MODELS.nutrition, 1500);

--- a/backend/test/ai.test.js
+++ b/backend/test/ai.test.js
@@ -15,7 +15,15 @@ const mockUser = {
 };
 const mockPrisma = {
   $queryRaw: jest.fn().mockResolvedValue([{ test: 1 }]),
-  user: { findUnique: jest.fn().mockResolvedValue(mockUser) }
+  user: { findUnique: jest.fn().mockResolvedValue(mockUser) },
+  mealPlan: {
+    create: jest.fn().mockResolvedValue({ id: 1 }),
+    findUnique: jest.fn().mockResolvedValue({ id: 1, name: 'Plano Alimentar IA', date: '2024-01-01', meals: [] })
+  },
+  meal: { create: jest.fn().mockResolvedValue({ id: 1 }) },
+  food: { create: jest.fn().mockResolvedValue({ id: 1 }) },
+  mealFood: { create: jest.fn().mockResolvedValue({}) },
+  $transaction: jest.fn(async (cb) => cb(mockPrisma))
 };
 
 jest.mock('@prisma/client', () => ({
@@ -25,7 +33,20 @@ jest.mock('@prisma/client', () => ({
 // Mock AI service functions
 jest.mock('../services/aiService', () => ({
   generateWorkoutPlan: jest.fn().mockResolvedValue({ plan: 'workout' }),
-  generateMealPlan: jest.fn().mockResolvedValue({ plan: 'meal' }),
+  generateMealPlan: jest
+    .fn()
+    .mockResolvedValue(
+      JSON.stringify({
+        meals: [
+          {
+            name: 'Café da manhã',
+            items: [
+              { name: 'Ovos', quantity: 2, calories: 150, protein: 12, carbs: 1, fat: 10 }
+            ]
+          }
+        ]
+      })
+    ),
   generateHealthAssessment: jest.fn().mockResolvedValue({ status: 'ok' }),
   analyzeHealthDocument: jest.fn().mockResolvedValue({ summary: 'analysis' }),
   answerQuestion: jest.fn().mockResolvedValue('answer')


### PR DESCRIPTION
## Summary
- ask nutrition model to reply with structured JSON for meals
- parse AI meal plan, persist MealPlan/Meal/MealFood records, and return saved plan
- update AI route tests for new JSON parsing

## Testing
- `npm test` (fails: Missing script)
- `npx jest backend/test/ai.test.js backend/test/mealPlan.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf8bb4bdf083298911c7dd38846e58