### PR TITLE
Use user profile in AI plan prompts

### DIFF
--- a/src/components/nutrition/MealPlanFormWithAI.tsx
+++ b/src/components/nutrition/MealPlanFormWithAI.tsx
@@ -67,14 +67,21 @@ const MealPlanFormWithAI: React.FC<MealPlanFormWithAIProps> = ({
       
       // Dados do usuário para a IA
       const userData = {
-        age: user?.birthdate ? Math.floor((new Date().getTime() - new Date(user.birthdate).getTime()) / (365.25 * 24 * 60 * 60 * 1000)) : null,
+        age: user?.birthdate
+          ? Math.floor(
+              (Date.now() - new Date(user.birthdate).getTime()) /
+                (365.25 * 24 * 60 * 60 * 1000)
+            )
+          : undefined,
         weight: user?.weight,
         height: user?.height,
-        goal: 'melhorar a saúde'
+        goal: (user as any)?.goal,
+        dietaryRestrictions: (user as any)?.dietaryRestrictions,
+        foodPreferences: (user as any)?.foodPreferences,
       };
-      
+
       const nutritionalGoals = user?.nutritionGoals || {};
-      
+
       // Chamar a IA para gerar o plano
       const response = await generateAIMealPlan({ userData, nutritionalGoals });
       

--- a/src/components/workout/WorkoutFormWithAI.tsx
+++ b/src/components/workout/WorkoutFormWithAI.tsx
@@ -23,7 +23,7 @@ const WorkoutFormWithAI: React.FC<WorkoutFormWithAIProps> = ({
   initialWorkout,
   exercises = []
 }) => {
-  const { generateAIWorkoutPlan } = useAppContext();
+  const { generateAIWorkoutPlan, user } = useAppContext();
   const { toast } = useToast();
 
   // Usar exercises da prop ou array vazio
@@ -141,12 +141,20 @@ const WorkoutFormWithAI: React.FC<WorkoutFormWithAIProps> = ({
       
       // Dados do usuário para a IA
       const userData = {
-        goal: 'melhorar a saúde',
-        fitnessLevel: 'intermediário',
-        availableDays: 5,
-        equipment: 'academia completa',
-        injuries: 'nenhuma',
-        preferences: 'musculação'
+        age: user?.birthdate
+          ? Math.floor(
+              (Date.now() - new Date(user.birthdate).getTime()) /
+                (365.25 * 24 * 60 * 60 * 1000)
+            )
+          : undefined,
+        weight: user?.weight,
+        height: user?.height,
+        goal: (user as any)?.goal,
+        fitnessLevel: (user as any)?.fitnessLevel,
+        availableDays: (user as any)?.availableDays,
+        equipment: (user as any)?.equipment,
+        injuries: (user as any)?.injuries,
+        preferences: (user as any)?.workoutPreferences || (user as any)?.preferences,
       };
       
       // Chamar a IA para gerar o plano


### PR DESCRIPTION
## Summary
- Source workout and meal plan prompts from the logged-in user's profile, including age, weight, height, and goals.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: TypeError loading @typescript-eslint/no-unused-expressions)


------
https://chatgpt.com/codex/tasks/task_e_68bf8bb9054c832994cec00b3f2b9496