### PR TITLE
feat: store raw AI responses with plans

### DIFF
--- a/backend/prisma/migrations/20241001000000_add_raw_response/migration.sql
+++ b/backend/prisma/migrations/20241001000000_add_raw_response/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workout_plans" ADD COLUMN "raw_response" TEXT;
+ALTER TABLE "meal_plans" ADD COLUMN "raw_response" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -85,14 +85,15 @@ model Badge {
 }
 
 model WorkoutPlan {
-  id          Int      @id @default(autoincrement())
-  name        String
-  day_of_week Int // 0-6, domingo a sábado
-  notes       String?
-  user_id     Int
-  is_public   Boolean  @default(false)
-  created_at  DateTime @default(now())
-  updated_at  DateTime @updatedAt
+  id           Int      @id @default(autoincrement())
+  name         String
+  day_of_week  Int // 0-6, domingo a sábado
+  notes        String?
+  user_id      Int
+  is_public    Boolean  @default(false)
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
+  raw_response String?  @db.Text
 
   user      User                  @relation(fields: [user_id], references: [id], onDelete: Cascade)
   exercises WorkoutPlanExercise[]
@@ -231,15 +232,16 @@ model NutritionGoals {
 }
 
 model MealPlan {
-  id        Int     @id @default(autoincrement())
-  name      String
-  date      String
-  frequency String?
-  notes     String?
-  userId    Int
-  is_public Boolean @default(false)
-  user      User    @relation(fields: [userId], references: [id])
-  meals     Meal[]  @relation("MealPlanMeals")
+  id           Int     @id @default(autoincrement())
+  name         String
+  date         String
+  frequency    String?
+  notes        String?
+  userId       Int
+  is_public    Boolean @default(false)
+  raw_response String? @db.Text
+  user         User    @relation(fields: [userId], references: [id])
+  meals        Meal[]  @relation("MealPlanMeals")
 
   @@map("meal_plans")
 }
@@ -256,12 +258,12 @@ model Meal {
 }
 
 model MealFood {
-  id      Int   @id @default(autoincrement())
-  mealId  Int
-  meal    Meal  @relation("MealMealFoods", fields: [mealId], references: [id], onDelete: Cascade)
+  id       Int   @id @default(autoincrement())
+  mealId   Int
+  meal     Meal  @relation("MealMealFoods", fields: [mealId], references: [id], onDelete: Cascade)
   quantity Float @default(1)
-  foodId  Int
-  food    Food  @relation(fields: [foodId], references: [id])
+  foodId   Int
+  food     Food  @relation(fields: [foodId], references: [id])
 
   @@map("meal_foods")
 }
@@ -288,7 +290,7 @@ model UserSettings {
 model Consent {
   id        Int      @id @default(autoincrement())
   userId    Int
-  kind      String   // analytics | marketing | ai_training | etc
+  kind      String // analytics | marketing | ai_training | etc
   granted   Boolean
   timestamp DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -298,12 +300,12 @@ model Consent {
 }
 
 model DeletionRequest {
-  id          Int      @id @default(autoincrement())
+  id          Int       @id @default(autoincrement())
   userId      Int
-  status      String   // scheduled | completed | canceled
+  status      String // scheduled | completed | canceled
   scheduledAt DateTime?
-  created_at  DateTime @default(now())
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  created_at  DateTime  @default(now())
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, status])
   @@map("deletion_requests")
@@ -312,7 +314,7 @@ model DeletionRequest {
 model DataExportLog {
   id         Int      @id @default(autoincrement())
   userId     Int
-  status     String   // pending | ready | error
+  status     String // pending | ready | error
   url        String?
   created_at DateTime @default(now())
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/routes/nutrition.js
+++ b/backend/routes/nutrition.js
@@ -26,9 +26,10 @@ function attachNutrition(plan) {
     totals.fat += nutrition.fat;
     return { ...meal, nutrition };
   });
-  const { is_public, ...rest } = plan;
+  const { is_public, raw_response, ...rest } = plan;
   return {
     ...rest,
+    rawResponse: raw_response,
     meals,
     isPublic: plan.isPublic ?? is_public ?? false,
     totalNutrition: totals,
@@ -268,7 +269,7 @@ router.get('/meal-plans/public', auth, async (req, res) => {
 router.post('/meal-plans', auth, async (req, res) => {
   try {
     console.log('Criando plano alimentar, dados recebidos:', JSON.stringify(req.body, null, 2));
-    const { name, date, frequency, meals, notes, isPublic } = req.body;
+    const { name, date, frequency, meals, notes, isPublic, rawResponse } = req.body;
     
     if (!name || !date) {
       return res.status(400).json({ message: 'Nome e data são obrigatórios' });
@@ -289,6 +290,7 @@ router.post('/meal-plans', auth, async (req, res) => {
           frequency: frequency || null,
           notes: notes || null,
           is_public: Boolean(isPublic), // <- ajustado
+          raw_response: rawResponse || null,
           userId
         }
       });
@@ -386,7 +388,7 @@ router.put('/meal-plans/:id', auth, async (req, res) => {
   try {
     const id = parseInt(req.params.id);
     const userId = parseInt(req.user.id);
-  const { name, date, frequency, meals, notes, isPublic } = req.body;
+    const { name, date, frequency, meals, notes, isPublic, rawResponse } = req.body;
     
     console.log(`Tentando atualizar plano alimentar com ID: ${id}`);
     console.log('Dados recebidos:', JSON.stringify(meals, null, 2));
@@ -463,6 +465,7 @@ router.put('/meal-plans/:id', auth, async (req, res) => {
         frequency: frequency || null,
         notes: notes || null,
         is_public: Boolean(isPublic),
+        ...(rawResponse !== undefined ? { raw_response: rawResponse } : {}),
         meals: {
           create: validMeals.map(meal => ({
             name: meal.name || 'Refeição',

--- a/backend/routes/workouts.js
+++ b/backend/routes/workouts.js
@@ -34,6 +34,7 @@ router.get('/plans', auth, async (req, res) => {
       dayOfWeek: plan.day_of_week,
       notes: plan.notes,
       isPublic: plan.is_public,
+      rawResponse: plan.raw_response,
       exercises: plan.exercises.map(pe => ({
         id: pe.exercise.id.toString(),
         name: pe.exercise.name,
@@ -62,7 +63,7 @@ router.post('/plans', auth, async (req, res) => {
       return res.status(401).json({ message: 'Unauthorized' });
     }
     
-    const { name, dayOfWeek, exercises, notes, isPublic } = req.body;
+    const { name, dayOfWeek, exercises, notes, isPublic, rawResponse } = req.body;
     
     const workoutPlan = await prisma.$transaction(async (tx) => {
       // 1. Criar o plano
@@ -72,7 +73,8 @@ router.post('/plans', auth, async (req, res) => {
           day_of_week: dayOfWeek,
           notes: notes || null,
           is_public: Boolean(isPublic),
-          user_id: userId
+          user_id: userId,
+          raw_response: rawResponse || null
         }
       });
       
@@ -116,6 +118,7 @@ router.post('/plans', auth, async (req, res) => {
       dayOfWeek: workoutPlan.day_of_week,
       notes: workoutPlan.notes,
       isPublic: workoutPlan.is_public,
+      rawResponse: workoutPlan.raw_response,
       exercises: workoutPlan.exercises.map(pe => ({
         id: pe.exercise.id.toString(),
         name: pe.exercise.name,
@@ -145,7 +148,7 @@ router.put('/plans/:id', auth, async (req, res) => {
       return res.status(401).json({ message: 'Unauthorized' });
     }
     
-    const { name, dayOfWeek, exercises, notes, isPublic } = req.body;
+    const { name, dayOfWeek, exercises, notes, isPublic, rawResponse } = req.body;
     
     const updatedPlan = await prisma.$transaction(async (tx) => {
       // Verificar se o plano pertence ao usuário
@@ -164,7 +167,8 @@ router.put('/plans/:id', auth, async (req, res) => {
           name,
           day_of_week: dayOfWeek,
           notes: notes || null,
-          is_public: Boolean(isPublic)
+          is_public: Boolean(isPublic),
+          ...(rawResponse !== undefined ? { raw_response: rawResponse } : {})
         }
       });
       
@@ -213,6 +217,7 @@ router.put('/plans/:id', auth, async (req, res) => {
       dayOfWeek: updatedPlan.day_of_week,
       notes: updatedPlan.notes,
       isPublic: updatedPlan.is_public,
+      rawResponse: updatedPlan.raw_response,
       exercises: updatedPlan.exercises.map(pe => ({
         id: pe.exercise.id.toString(),
         name: pe.exercise.name,
@@ -523,6 +528,7 @@ router.get('/plans/public', auth, async (req, res) => {
       dayOfWeek: plan.day_of_week,
       notes: plan.notes,
       isPublic: plan.is_public,
+      rawResponse: plan.raw_response,
       exercises: plan.exercises.map(pe => ({
         id: pe.exercise.id.toString(),
         name: pe.exercise.name,

--- a/backend/test/mealPlan.test.js
+++ b/backend/test/mealPlan.test.js
@@ -43,19 +43,20 @@ describe('Meal Plans API', () => {
 
   test('creates a meal plan', async () => {
     mockPrisma.mealPlan.create.mockResolvedValueOnce({ id: 1 });
-    mockPrisma.mealPlan.findUnique.mockResolvedValueOnce({ id: 1, name: 'Plan', date: '2024-01-01', meals: [] });
+    mockPrisma.mealPlan.findUnique.mockResolvedValueOnce({ id: 1, name: 'Plan', date: '2024-01-01', meals: [], raw_response: 'raw meal' });
 
     const res = await request(app)
       .post('/api/nutrition/meal-plans')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Plan', date: '2024-01-01', meals: [] });
+      .send({ name: 'Plan', date: '2024-01-01', meals: [], rawResponse: 'raw meal' });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body).toHaveProperty('name', 'Plan');
+    expect(res.body).toHaveProperty('rawResponse', 'raw meal');
+    expect(mockPrisma.mealPlan.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ raw_response: 'raw meal' }) }));
   });
 
   test('lists user meal plans', async () => {
-    mockPrisma.mealPlan.findMany.mockResolvedValueOnce([{ id: 1, name: 'Plan', date: '2024-01-01', meals: [], is_public: false }]);
+    mockPrisma.mealPlan.findMany.mockResolvedValueOnce([{ id: 1, name: 'Plan', date: '2024-01-01', meals: [], is_public: false, raw_response: 'raw meal' }]);
 
     const res = await request(app)
       .get('/api/nutrition/meal-plans')
@@ -63,6 +64,7 @@ describe('Meal Plans API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toHaveProperty('rawResponse', 'raw meal');
   });
 
   test('updates a meal plan', async () => {

--- a/backend/test/workouts.test.js
+++ b/backend/test/workouts.test.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken');
 
 process.env.JWT_SECRET = 'testsecret';
 
-const mockPlan = { id: 1, name: 'Plan', day_of_week: 'monday', notes: null, exercises: [] };
+const mockPlan = { id: 1, name: 'Plan', day_of_week: 'monday', notes: null, exercises: [], raw_response: 'raw text' };
 
 const mockPrisma = {
   $queryRaw: jest.fn().mockResolvedValue([{ test: 1 }]),
@@ -39,10 +39,11 @@ describe('Workout Plans API', () => {
     const res = await request(app)
       .post('/api/workouts/plans')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Plan', dayOfWeek: 'monday', exercises: [] });
+      .send({ name: 'Plan', dayOfWeek: 'monday', exercises: [], rawResponse: 'raw text' });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body).toHaveProperty('name', 'Plan');
+    expect(res.body).toHaveProperty('rawResponse', 'raw text');
+    expect(mockPrisma.workoutPlan.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ raw_response: 'raw text' }) }));
   });
 
   test('lists workout plans', async () => {
@@ -52,6 +53,7 @@ describe('Workout Plans API', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.statusCode).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toHaveProperty('rawResponse', 'raw text');
   });
 
   test('updates a workout plan', async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface WorkoutPlan {
   dayOfWeek: number; // 0-6, domingo a sábado
   notes?: string;
   isPublic?: boolean;
+  rawResponse?: string;
 }
 
 export interface WorkoutLog {
@@ -71,6 +72,7 @@ export interface MealPlan {
   meals: Meal[];
   notes?: string;
   isPublic?: boolean;
+  rawResponse?: string;
   totalNutrition?: {
     calories: number;
     protein: number;


### PR DESCRIPTION
## Summary
- store raw AI responses on workout and meal plans
- expose raw AI text in plan retrieval endpoints
- update tests and types to handle rawResponse

## Testing
- `npx jest backend/test/workouts.test.js backend/test/mealPlan.test.js`
- `npx jest backend/test`
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma migrate dev --name add-raw-response --create-only` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8bb9e1088329b13c93119ea9c5e1