### PR TITLE
feat: store AI meal plan

### DIFF
--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -108,14 +108,31 @@ async function generateMealPlan(userData, nutritionalGoals) {
     - Carboidratos: ${nutritionalGoals.carbs || 'Não informado'} g
     - Gorduras: ${nutritionalGoals.fat || 'Não informado'} g
     
-    Por favor, crie um plano alimentar para um dia com:
+    Gere um plano alimentar para um dia com:
     1. 3 refeições principais (café da manhã, almoço, jantar)
     2. 2 lanches
-    3. Detalhes nutricionais para cada refeição
-    4. Sugestões de alimentos específicos
-    5. Quantidades em gramas ou porções
-    
-    Formate a resposta como um plano alimentar estruturado, fácil de ler e seguir.
+    3. Detalhes nutricionais para cada alimento
+    4. Quantidades em gramas ou porções
+
+    Responda APENAS com JSON válido seguindo este formato:
+    {
+      "meals": [
+        {
+          "name": "Nome da refeição",
+          "items": [
+            {
+              "name": "Alimento",
+              "quantity": 0,
+              "calories": 0,
+              "protein": 0,
+              "carbs": 0,
+              "fat": 0
+            }
+          ]
+        }
+      ]
+    }
+    Não inclua nenhum texto fora do JSON.
   `;
 
   return await callOpenRouter(prompt, AI_MODELS.nutrition, 1500);

--- a/backend/test/ai.test.js
+++ b/backend/test/ai.test.js
@@ -15,7 +15,17 @@ const mockUser = {
 };
 const mockPrisma = {
   $queryRaw: jest.fn().mockResolvedValue([{ test: 1 }]),
-  user: { findUnique: jest.fn().mockResolvedValue(mockUser) }
+  user: { findUnique: jest.fn().mockResolvedValue(mockUser) },
+  mealPlan: {
+    create: jest.fn().mockResolvedValue({ id: 1 }),
+    findUnique: jest
+      .fn()
+      .mockResolvedValue({ id: 1, name: 'Plano Alimentar IA', date: '2024-01-01', meals: [] })
+  },
+  meal: { create: jest.fn().mockResolvedValue({ id: 1 }) },
+  food: { create: jest.fn().mockResolvedValue({ id: 1 }) },
+  mealFood: { create: jest.fn().mockResolvedValue({}) },
+  $transaction: jest.fn(async (cb) => cb(mockPrisma))
 };
 
 jest.mock('@prisma/client', () => ({
@@ -25,7 +35,20 @@ jest.mock('@prisma/client', () => ({
 // Mock AI service functions
 jest.mock('../services/aiService', () => ({
   generateWorkoutPlan: jest.fn().mockResolvedValue({ plan: 'workout' }),
-  generateMealPlan: jest.fn().mockResolvedValue({ plan: 'meal' }),
+  generateMealPlan: jest
+    .fn()
+    .mockResolvedValue(
+      JSON.stringify({
+        meals: [
+          {
+            name: 'Café da manhã',
+            items: [
+              { name: 'Ovos', quantity: 2, calories: 150, protein: 12, carbs: 1, fat: 10 }
+            ]
+          }
+        ]
+      })
+    ),
   generateHealthAssessment: jest.fn().mockResolvedValue({ status: 'ok' }),
   analyzeHealthDocument: jest.fn().mockResolvedValue({ summary: 'analysis' }),
   answerQuestion: jest.fn().mockResolvedValue('answer')


### PR DESCRIPTION
## Summary
- ask nutrition model to reply with structured JSON for meals
- parse AI meal plan, persist MealPlan/Meal/MealFood records, and return saved plan
- update AI route tests for new JSON parsing

## Testing
- `npm test` (fails: Missing script: "test")
- `npx jest backend/test/ai.test.js backend/test/mealPlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf8bb4bdf083298911c7dd38846e58